### PR TITLE
Update camera_test.py to have its camera's xclk_freq be XCLK_10MHz 

### DIFF
--- a/demos/camera_test.py
+++ b/demos/camera_test.py
@@ -77,7 +77,7 @@ camera.init(
     format=camera.JPEG,
     framesize=camera.FRAME_240X240,
     fb_location=camera.PSRAM,
-    xclk_freq=camera.XCLK_20MHz,
+    xclk_freq=camera.XCLK_10MHz,
     sioc=9,  # SCL
     siod=8,  # SDA
     vsync=7, href=6,


### PR DESCRIPTION
## Purpose
The current `xclk_freq` for the `camera` object in `camera_test.py` should be set to a lower frequency to prevent the camera from crashing or not working.

## Implementation
In `camera.init` in `camera_test.py` set `xclk_freq` to `camera.XCLK_10MHz` -- replacing the previous value of `camera.XCLK_20MHz`.